### PR TITLE
[Bug Fix] Fix SDPBasedLipschitzLinearLayer

### DIFF
--- a/core/models/layers.py
+++ b/core/models/layers.py
@@ -58,9 +58,9 @@ class SDPBasedLipschitzLinearLayer(nn.Module):
   def forward(self, x):
     res = F.linear(x, self.weights, self.bias)
     res = self.activation(res)
-    q_abs = torch.abs(self.q)
+    q_abs = torch.abs(self.q) + self.epsilon
     q = q_abs[None, :]
-    q_inv = (1/(q_abs+self.epsilon))[:, None]
+    q_inv = (1/q_abs)[:, None]
     T = 2/torch.abs(q_inv * self.weights @ self.weights.T * q).sum(1)
     res = T * res
     res = F.linear(res, self.weights.t())


### PR DESCRIPTION
The original `SDPBasedLipschitzLinearLayer` can have a Lipschitz lower bound larger than 1 if `self.q` is much smaller than `self.epsilon`